### PR TITLE
Allow the use of an URL instead of hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ pyNetgear works with Python 2 and 3.
 If you are connected to the network of the Netgear router, a host is optional.
 If you are connected via a wired connection to the Netgear router, a password is optional.
 The username defaults to admin.
-The port defaults to 5000
+The port defaults to 5000.
+You can specify url and it will take precedence on host and port parameters.
+This allows the use of HTTPS, `https://orbilogin.com` for example.
 
 It currently supports the following operations:
 
@@ -33,8 +35,8 @@ To test run from the console:
 
 To use within your Python scripts:
 ```python
-# All four parameters are optional
-netgear = Netgear(password, host, username, port)
+# All five parameters are optional
+netgear = Netgear(password, host, username, port, url)
 
 for i in netgear.get_attached_devices():
     print i

--- a/pynetgear/__init__.py
+++ b/pynetgear/__init__.py
@@ -22,13 +22,16 @@ class Netgear(object):
     """Represents a session to a Netgear Router."""
 
     def __init__(self, password=None, host=DEFAULT_HOST, user=DEFAULT_USER,
-                 port=DEFAULT_PORT):
+                 port=DEFAULT_PORT, url=None):
         """Initialize a Netgear session."""
-        self.soap_url = "http://{}:{}/soap/server_sa/".format(host, port)
+        if url:
+            self.soap_url = url + "/soap/server_sa/"
+        else:
+            self.soap_url = "http://{}:{}/soap/server_sa/".format(host, port)
         self.username = user
         self.password = password
         self.port = port
-        self.logged_in = host is DEFAULT_HOST
+        self.logged_in = False
 
     def login(self):
         """
@@ -171,16 +174,16 @@ class Netgear(object):
         headers = _get_soap_header(action)
 
         try:
-            req = requests.post(
-                self.soap_url, headers=headers, data=message, timeout=10)
+            req = requests.post(self.soap_url, headers=headers,
+                                data=message, timeout=10, verify=False)
 
             success = _is_valid_response(req)
 
             if not success and try_login_after_failure:
                 self.login()
 
-                req = requests.post(
-                    self.soap_url, headers=headers, data=message, timeout=10)
+                req = requests.post(self.soap_url, headers=headers,
+                                    data=message, timeout=10, verify=False)
 
                 success = _is_valid_response(req)
 


### PR DESCRIPTION
This allows the use of HTTPS.
Certificate verification is disabled since the cert presented
by the router will be self-signed.