### PR TITLE
Fix for failing parse for WNR3500Lv2 router

### DIFF
--- a/pynetgear/__init__.py
+++ b/pynetgear/__init__.py
@@ -290,8 +290,7 @@ def _find_node(response, xpath):
     for _, el in it:
         if '}' in el.tag:
             el.tag = el.tag.split('}', 1)[1]
-    root = it.root
-    node = root.find(xpath)
+    node = it.root.find(xpath)
     if node is None:
         _LOGGER.error("Error finding node in response: %s", response)
         return False, None


### PR DESCRIPTION
Unfortunately, Python's xml.etree has very limited support for XPath syntax and `.//*[local-name()='NewAttachDevice']` didn't work. 

I did some digging and found a way to strip namespaces completely: 
https://stackoverflow.com/questions/13412496/python-elementtree-module-how-to-ignore-the-namespace-of-xml-files-to-locate-ma/33997423

The proposed changes use the code snippet from stackoverflow to strip namespaces completely.