### PR TITLE
Allow four-digit response codes for Nighthawk M1 compatibility

### DIFF
--- a/pynetgear/__init__.py
+++ b/pynetgear/__init__.py
@@ -345,7 +345,8 @@ def _get_soap_header(service, method):
 
 def _is_valid_response(resp):
     return (resp.status_code == 200 and
-            "<ResponseCode>000</ResponseCode>" in resp.text)
+            ("<ResponseCode>0000</ResponseCode>" in resp.text or 
+            "<ResponseCode>000</ResponseCode>" in resp.text))
 
 
 def _convert(value, to_type, default=None):


### PR DESCRIPTION
This two-line change seems to make pynetgear compatible with Nighthawk M1 router.

Refs #13 