### PR TITLE
Added Content-Type Header & v1/v2 Login Logic

### DIFF
--- a/pynetgear/__init__.py
+++ b/pynetgear/__init__.py
@@ -79,11 +79,11 @@ class Netgear(object):
 
         Will be called automatically by other actions.
         """
-        v1_result = self.login_v1()
-        if v1_result is not any([None, False]):
-            return v1_result
+        v2_result = self.login_v2()
+        if v2_result:
+            return v2_result
         else:
-            return self.login_v2()
+            return self.login_v1()
 
     def login_v2(self):
         _LOGGER.info("Login v2")
@@ -377,8 +377,7 @@ def _get_soap_headers(service, method):
         "SOAPAction":    action,
         "Cache-Control": "no-cache",
         "User-Agent":    "pynetgear",
-        "Connection":    "Keep-Alive",
-        "Content-Type":  "application/xml"
+        "Content-Type":  "multipart/form-data"
     }
 
 

--- a/pynetgear/__init__.py
+++ b/pynetgear/__init__.py
@@ -79,7 +79,11 @@ class Netgear(object):
 
         Will be called automatically by other actions.
         """
-        return self.login_v2()
+        v1_result = self.login_v1()
+        if v1_result is not any([None, False]):
+            return v1_result
+        else:
+            return self.login_v2()
 
     def login_v2(self):
         _LOGGER.info("Login v2")
@@ -374,6 +378,7 @@ def _get_soap_headers(service, method):
         "Cache-Control": "no-cache",
         "User-Agent":    "pynetgear",
         "Connection":    "Keep-Alive",
+        "Content-Type":  "application/xml"
     }
 
 


### PR DESCRIPTION
Closes Issue #47 

 - Fixed communication issues for some models by adding the `Content-Type: application/xml` header to the `_get_soap_headers` function. Without it, some models (mine included) would have their requests immediately rejected with a `connection was reset` error message, causing all attempts to communicate with the router to fail.
 - Added v1/v2 Login logic to broaden support for older models

**Personal Side Note:** Coincidentally, after adding the `Content-Type` header my router successfully responded to the v1 login flow :grimacing: 