### PR TITLE
reset headers to use new cookie after reauthorization

### DIFF
--- a/pynetgear/__init__.py
+++ b/pynetgear/__init__.py
@@ -379,6 +379,7 @@ class Netgear(object):
 
                 _LOGGER.warning("Unauthorized response, let's login and retry...")
                 if self.login():
+                    headers = self._get_headers(service, method, need_auth) #reset headers with new cookie
                     response = requests.post(self.soap_url, headers=headers,
                                              data=message, timeout=30, verify=False)
 


### PR DESCRIPTION
Headers need to be re-created to use the new cookie that was received in self.login(). This will allow long running instances to continue to reauthorize, as with Home Assistant.