### PR TITLE
Add Dockerfile to wrap pynetgear's CLI

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:alpine3.8
+RUN pip3 install pynetgear
+ENTRYPOINT [ "python", "-m",  "pynetgear" ]


### PR DESCRIPTION
Allows for users to use the tool via docker instead of with their current python install.