### PR TITLE
Fixes/double unknown missing semicolon

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,13 +1,13 @@
 before_script:
   - pip install flake8
 
-python34:
-  image: python:3.4
+python37:
+  image: python:3.7
   script:
   - flake8 pynetgear
+  - python test/test_getAttachedDevices.py
 
 python27:
   image: python:2.7
   script:
   - flake8 pynetgear
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,18 @@
 language: python
-python:
-  - '3.4'
-  - '2.7'
+os: linux
 
 before_install:
   - pip install flake8
-script:
-  - flake8 pynetgear
+
+jobs:
+  include:
+    - stage: lint
+      python: 3.7
+      script: flake8 pynetgear
+    - stage: test
+      python: 3.7
+      script: python test/test_getAttachedDevices.py
+
+stages:
+  - lint
+  - test

--- a/pynetgear/__init__.py
+++ b/pynetgear/__init__.py
@@ -140,7 +140,7 @@ class Netgear(object):
             return None
 
         success, node = _find_node(
-            response.text,
+            _fix_double_unknown(response.text),
             ".//GetAttachDeviceResponse/NewAttachDevice")
         if not success:
             return None
@@ -478,6 +478,12 @@ def _convert(value, to_type, default=None):
     except ValueError:
         # If value could not be converted
         return default
+
+
+def _fix_double_unknown(text):
+    """Add missing semicolon between two <unknown>'s."""
+    return text.replace("&lt;unknown&gt;&lt;unknown&gt;",
+                        "&lt;unknown&gt;;&lt;unknown&gt;")
 
 
 SERVICE_PREFIX = "urn:NETGEAR-ROUTER:service:"

--- a/test/test_getAttachedDevices.py
+++ b/test/test_getAttachedDevices.py
@@ -3,17 +3,19 @@ from unittest import mock
 
 # Import from the local version of pynetgear
 from inspect import getsourcefile
-import os.path as path, sys
-current_dir = path.dirname(path.abspath(getsourcefile(lambda:0)))
-netgear_dir = current_dir + '/../pynetgear'
+import sys
+import os.path as path
+
+current_dir = path.dirname(path.abspath(getsourcefile(lambda: 0)))
+netgear_dir = current_dir + "/../pynetgear"
 sys.path.insert(0, netgear_dir)
-from __init__ import Netgear, Device
+from __init__ import Netgear, Device  # noqa: E402
 
 
 class TestGetAttachedDevices(unittest.TestCase):
     def test_noSignalType(self):
         spy = NetgearSpy(RESPONSE_NO_SIGNAL_TYPE)
-        mocked_netgear = mock.Mock(wraps=spy)
+        mock.Mock(wraps=spy)
 
         result = spy.get_attached_devices()
         assert result == [
@@ -47,7 +49,7 @@ class TestGetAttachedDevices(unittest.TestCase):
 
     def test_withSignalType(self):
         spy = NetgearSpy(RESPONSE_WITH_SIGNAL_TYPE)
-        mocked_netgear = mock.Mock(wraps=spy)
+        mock.Mock(wraps=spy)
 
         result = spy.get_attached_devices()
         assert result == [
@@ -81,19 +83,19 @@ class TestGetAttachedDevices(unittest.TestCase):
 
     def test_invalidResponse(self):
         spy = NetgearSpy(RESPONSE_INVALID)
-        mocked_netgear = mock.Mock(wraps=spy)
+        mock.Mock(wraps=spy)
         result = spy.get_attached_devices()
         assert result is None
 
     def test_responseMissingSplitChar(self):
         spy = NetgearSpy(RESPONSE_MISSGING_SPLIT_CHAR)
-        mocked_netgear = mock.Mock(wraps=spy)
+        mock.Mock(wraps=spy)
         result = spy.get_attached_devices()
         assert result == []
 
     def test_responseUnknownDevice(self):
         spy = NetgearSpy(RESONSE_UNKOWN_DEVICE)
-        mocked_netgear = mock.Mock(wraps=spy)
+        mock.Mock(wraps=spy)
         result = spy.get_attached_devices()
         assert result == [
             Device(
@@ -110,10 +112,10 @@ class TestGetAttachedDevices(unittest.TestCase):
                 conn_ap_mac=None,
             )
         ]
-    
+
     def test_double_unknown_response(self):
         spy = NetgearSpy(RESPONSE_DOUBLE_UNKNOWN)
-        mocked_netgear = mock.Mock(wraps=spy)
+        mock.Mock(wraps=spy)
         result = spy.get_attached_devices()
         assert result == [
             Device(
@@ -130,7 +132,6 @@ class TestGetAttachedDevices(unittest.TestCase):
                 conn_ap_mac=None,
             )
         ]
-
 
 
 class NetgearSpy(Netgear):
@@ -152,7 +153,8 @@ class MockResponse:
             xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
             SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
             <SOAP-ENV:Body>
-            <m:GetAttachDeviceResponse xmlns:m="urn:NETGEAR-ROUTER:service:DeviceInfo:1">"""
+            <m:GetAttachDeviceResponse
+            xmlns:m="urn:NETGEAR-ROUTER:service:DeviceInfo:1">"""
             + text
             + """
             </m:GetAttachDeviceResponse>

--- a/test/test_getAttachedDevices.py
+++ b/test/test_getAttachedDevices.py
@@ -1,6 +1,13 @@
 import unittest
 from unittest import mock
-from pynetgear import Netgear, Device
+
+# Import from the local version of pynetgear
+from inspect import getsourcefile
+import os.path as path, sys
+current_dir = path.dirname(path.abspath(getsourcefile(lambda:0)))
+netgear_dir = current_dir + '/../pynetgear'
+sys.path.insert(0, netgear_dir)
+from __init__ import Netgear, Device
 
 
 class TestGetAttachedDevices(unittest.TestCase):
@@ -103,6 +110,27 @@ class TestGetAttachedDevices(unittest.TestCase):
                 conn_ap_mac=None,
             )
         ]
+    
+    def test_double_unknown_response(self):
+        spy = NetgearSpy(RESPONSE_DOUBLE_UNKNOWN)
+        mocked_netgear = mock.Mock(wraps=spy)
+        result = spy.get_attached_devices()
+        assert result == [
+            Device(
+                signal=88,
+                ip="<unknown>",
+                name="<unknown>",
+                mac="00:11:22:33:44:55",
+                type="wireless",
+                link_rate=84,
+                allow_or_block="Allow",
+                device_type=None,
+                device_model=None,
+                ssid=None,
+                conn_ap_mac=None,
+            )
+        ]
+
 
 
 class NetgearSpy(Netgear):
@@ -159,6 +187,12 @@ UNKNOWN#FORMATTING\
 RESONSE_UNKOWN_DEVICE = MockResponse(
     "<NewAttachDevice>\
 1@1;192.168.1.2;&lt;unknown&gt;;10:68:3F:AA:AA:AA\
+</NewAttachDevice>"
+)
+
+RESPONSE_DOUBLE_UNKNOWN = MockResponse(
+    "<NewAttachDevice>\
+@1;&lt;unknown&gt;&lt;unknown&gt;;00:11:22:33:44:55;wireless;84;88;Allow\
 </NewAttachDevice>"
 )
 

--- a/test/test_getAttachedDevices.py
+++ b/test/test_getAttachedDevices.py
@@ -4,31 +4,73 @@ from pynetgear import Netgear, Device
 
 
 class TestGetAttachedDevices(unittest.TestCase):
-
     def test_noSignalType(self):
         spy = NetgearSpy(RESPONSE_NO_SIGNAL_TYPE)
         mocked_netgear = mock.Mock(wraps=spy)
 
         result = spy.get_attached_devices()
-        assert result == [Device(signal=100, ip='192.168.1.4',
-                                 name='MACBOOK-PRO', mac='80:E6:50:13:2B:E0',
-                                 type=None, link_rate=0),
-                          Device(signal=100, ip='192.168.1.18',
-                                 name='RASPBERRYPI', mac='B8:27:EB:D9:05:E1',
-                                 type=None, link_rate=0)]
+        assert result == [
+            Device(
+                signal=None,
+                ip="192.168.1.4",
+                name="MACBOOK-PRO",
+                mac="80:E6:50:13:2B:E0",
+                type=None,
+                link_rate=None,
+                allow_or_block=None,
+                device_type=None,
+                device_model=None,
+                ssid=None,
+                conn_ap_mac=None,
+            ),
+            Device(
+                signal=None,
+                ip="192.168.1.18",
+                name="RASPBERRYPI",
+                mac="B8:27:EB:D9:05:E1",
+                type=None,
+                link_rate=None,
+                allow_or_block=None,
+                device_type=None,
+                device_model=None,
+                ssid=None,
+                conn_ap_mac=None,
+            ),
+        ]
 
     def test_withSignalType(self):
         spy = NetgearSpy(RESPONSE_WITH_SIGNAL_TYPE)
         mocked_netgear = mock.Mock(wraps=spy)
 
         result = spy.get_attached_devices()
-        assert result == [Device(signal=88, ip='192.168.1.2',
-                                 name='android-ada682e3ff4d6b20',
-                                 mac='10:68:3F:AA:AA:AA',
-                                 type='wireless', link_rate=72),
-                          Device(signal=100, ip='192.168.1.3', name='odin',
-                                 mac='C8:9C:DC:AA:AA:AA', type='wired',
-                                 link_rate=None)]
+        assert result == [
+            Device(
+                signal=88,
+                ip="192.168.1.2",
+                name="android-ada682e3ff4d6b20",
+                mac="10:68:3F:AA:AA:AA",
+                type="wireless",
+                link_rate=72,
+                allow_or_block=None,
+                device_type=None,
+                device_model=None,
+                ssid=None,
+                conn_ap_mac=None,
+            ),
+            Device(
+                signal=100,
+                ip="192.168.1.3",
+                name="odin",
+                mac="C8:9C:DC:AA:AA:AA",
+                type="wired",
+                link_rate=None,
+                allow_or_block=None,
+                device_type=None,
+                device_model=None,
+                ssid=None,
+                conn_ap_mac=None,
+            ),
+        ]
 
     def test_invalidResponse(self):
         spy = NetgearSpy(RESPONSE_INVALID)
@@ -40,20 +82,27 @@ class TestGetAttachedDevices(unittest.TestCase):
         spy = NetgearSpy(RESPONSE_MISSGING_SPLIT_CHAR)
         mocked_netgear = mock.Mock(wraps=spy)
         result = spy.get_attached_devices()
-        assert result is None
+        assert result == []
 
     def test_responseUnknownDevice(self):
         spy = NetgearSpy(RESONSE_UNKOWN_DEVICE)
         mocked_netgear = mock.Mock(wraps=spy)
         result = spy.get_attached_devices()
-        assert result == [Device(signal=100, ip='192.168.1.2',
-                                 name='<unknown>',
-                                 mac='10:68:3F:AA:AA:AA',
-                                 type=None, link_rate=0)]
-
-
-if __name__ == '__main__':
-    unittest.main()
+        assert result == [
+            Device(
+                signal=None,
+                ip="192.168.1.2",
+                name="<unknown>",
+                mac="10:68:3F:AA:AA:AA",
+                type=None,
+                link_rate=None,
+                allow_or_block=None,
+                device_type=None,
+                device_model=None,
+                ssid=None,
+                conn_ap_mac=None,
+            )
+        ]
 
 
 class NetgearSpy(Netgear):
@@ -67,22 +116,51 @@ class NetgearSpy(Netgear):
         return result, response
 
 
-RESPONSE_NO_SIGNAL_TYPE = "<NewAttachDevice>\
+class MockResponse:
+    def __init__(self, text):
+        self.text = (
+            """<?xml version="1.0" encoding="UTF-8"?>
+            <SOAP-ENV:Envelope
+            xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/"
+            SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+            <SOAP-ENV:Body>
+            <m:GetAttachDeviceResponse xmlns:m="urn:NETGEAR-ROUTER:service:DeviceInfo:1">"""
+            + text
+            + """
+            </m:GetAttachDeviceResponse>
+            <ResponseCode>000</ResponseCode>
+            </SOAP-ENV:Body>
+            </SOAP-ENV:Envelope>"""
+        )
+
+
+RESPONSE_NO_SIGNAL_TYPE = MockResponse(
+    "<NewAttachDevice>\
 2@1;192.168.1.4;MACBOOK-PRO;80:E6:50:13:2B:E0\
 @3;192.168.1.18;RASPBERRYPI;B8:27:EB:D9:05:E1\
 </NewAttachDevice>"
+)
 
-RESPONSE_WITH_SIGNAL_TYPE = "<NewAttachDevice>\
+RESPONSE_WITH_SIGNAL_TYPE = MockResponse(
+    "<NewAttachDevice>\
 2@1;192.168.1.2;android-ada682e3ff4d6b20;10:68:3F:AA:AA:AA;wireless;72;88\
 @2;192.168.1.3;odin;C8:9C:DC:AA:AA:AA;wired;;100\
 </NewAttachDevice>"
+)
 
-RESPONSE_INVALID = "INVALID"
+RESPONSE_INVALID = MockResponse("INVALID")
 
-RESPONSE_MISSGING_SPLIT_CHAR = "<NewAttachDevice>\
+RESPONSE_MISSGING_SPLIT_CHAR = MockResponse(
+    "<NewAttachDevice>\
 UNKNOWN#FORMATTING\
 </NewAttachDevice>"
+)
 
-RESONSE_UNKOWN_DEVICE = "<NewAttachDevice>\
+RESONSE_UNKOWN_DEVICE = MockResponse(
+    "<NewAttachDevice>\
 1@1;192.168.1.2;&lt;unknown&gt;;10:68:3F:AA:AA:AA\
 </NewAttachDevice>"
+)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
I'm using the Netgear device_tracker integration within Home Assistant. I was experiencing some weird behavior - sometimes connected devices would show up as having `ip="<unknown><unknown>"`, `mac="wireless"`, and other weirdness.

After inspecting the SOAP response, it seems there is a malformed response from the router:
```
@1;&lt;unknown&gt;&lt;unknown&gt;;00:11:22:33:44:55;wireless;84;88;Allow
```

If you look closely it's missing a semicolon between the two `<unknown>`s. 

Here's what it looks like in the "Attached devices" page of my router:
![Screen Shot 2019-11-16 at 9 02 38 PM](https://user-images.githubusercontent.com/8212321/69002021-574dad80-08b6-11ea-86d5-473cbed6db1e.png)

This PR adds the function `_fix_double_unknown()` that will insert a semicolon in the correct place so that the rest of the parsing works as intended. It also includes fixes for existing unit tests, a new unit test to cover this case, as well as an update to gitlab + travis CI to run these unit tests. I've been running it as a custom component within my Home Assistant and it works well.

Some more info on my specific Netgear router:
**WNR2000v4**, firmware version **V1.0.0.70**