### PR TITLE
Autodetect URL with timeout + test non HTTPS first

### DIFF
--- a/pynetgear/__init__.py
+++ b/pynetgear/__init__.py
@@ -408,13 +408,20 @@ def autodetect_url():
 
     Returns None if it can't be found.
     """
-    for url in ["http://routerlogin.net:5000", "https://routerlogin.net",
-                "http://routerlogin.net"]:
+    DETECTABLE_URLS = [
+        "http://routerlogin.net",
+        "http://routerlogin.net:5000",
+        "https://routerlogin.net",
+    ]
+    for url in DETECTABLE_URLS:
         try:
-            r = requests.get(url + "/soap/server_sa/",
-                             headers=_get_soap_headers("Test:1", "test"),
-                             verify=False)
-            if r.status_code == 200:
+            resp = requests.get(
+                url + "/soap/server_sa/",
+                headers=_get_soap_headers("Test:1", "test"),
+                verify=False,
+                timeout=1
+            )
+            if resp.status_code == 200:
                 return url
         except requests.exceptions.RequestException:
             pass


### PR DESCRIPTION
test non HTTPS url first to avoid:

```shell
python3.7/site-packages/urllib3/connectionpool.py:986: InsecureRequestWarning: Unverified HTTPS request is being made to host 'routerlogin.net'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
```