### PR TITLE
Check login with an info call

### DIFF
--- a/pynetgear/__init__.py
+++ b/pynetgear/__init__.py
@@ -101,6 +101,8 @@ class Netgear(object):
         self.cookie = None
         self.config_started = False
 
+        self._info = None
+
     def login(self):
         """
         Login to the router.
@@ -156,9 +158,13 @@ class Netgear(object):
 
         self.cookie = success
 
+        # check login succes with info call
+        if self.get_info(use_cache = False) is None:
+            return False
+
         return success
 
-    def get_info(self):
+    def get_info(self, use_cache = True):
         """
         Return router informations, like:
         - ModelName
@@ -174,6 +180,9 @@ class Netgear(object):
         """
         _LOGGER.debug("Get Info")
 
+        if self._info is not None and use_cache:
+            return self._info
+
         success, response = self._make_request(
             SERVICE_DEVICE_INFO,
             "GetInfo"
@@ -187,7 +196,9 @@ class Netgear(object):
         if not success:
             return None
 
-        return {t.tag: t.text for t in node}
+        self._info = {t.tag: t.text for t in node}
+
+        return self._info
 
     def get_attached_devices(self):
         """

--- a/pynetgear/__init__.py
+++ b/pynetgear/__init__.py
@@ -145,6 +145,10 @@ class Netgear(object):
             _LOGGER.debug(response.headers)
             return False
 
+        # check login succes with info call
+        if self.get_info(use_cache=False) is None:
+            return False
+
         return True
 
     def login_v1(self):

--- a/pynetgear/__init__.py
+++ b/pynetgear/__init__.py
@@ -159,12 +159,12 @@ class Netgear(object):
         self.cookie = success
 
         # check login succes with info call
-        if self.get_info(use_cache = False) is None:
+        if self.get_info(use_cache=False) is None:
             return False
 
         return success
 
-    def get_info(self, use_cache = True):
+    def get_info(self, use_cache=True):
         """
         Return router informations, like:
         - ModelName

--- a/pynetgear/__init__.py
+++ b/pynetgear/__init__.py
@@ -111,13 +111,13 @@ class Netgear(object):
 
         Will be called automatically by other actions.
         """
-        # cookie is also used to track if at least
-        # one login attempt has been made for v1
         if self._logging_in:
             _LOGGER.debug("Login re-attempt within the login, ignoring.")
             return False
-
         self._logging_in = True
+
+        # cookie is also used to track if at least
+        # one login attempt has been made for v1
         self.cookie = None
 
         if not self.force_login_v1:

--- a/pynetgear/__init__.py
+++ b/pynetgear/__init__.py
@@ -154,10 +154,6 @@ class Netgear(object):
             _LOGGER.debug(response.headers)
             return False
 
-        # check login succes with info call
-        if self.get_info(use_cache=False) is None:
-            return False
-
         return True
 
     def login_v1(self):


### PR DESCRIPTION
Sometimes a v1 login call can report succes while actually not beeing autorized to get info, v2 login does work in that case.
See: https://github.com/home-assistant/core/issues/59025 as an example.

This will check the V1 login call with a get_info call, if that fails, v2 login is automatically tried.