### PR TITLE
Fix ssl error

### DIFF
--- a/pynetgear/__init__.py
+++ b/pynetgear/__init__.py
@@ -580,8 +580,7 @@ class Netgear(object):
                 )
             except requests.exceptions.SSLError:
                 _LOGGER.debug("SSL error, thread as unauthorized response "
-                    "and try again after re-login"
-                )
+                              "and try again after re-login")
                 response = requests.Response()
                 response.status_code = 401
 

--- a/pynetgear/__init__.py
+++ b/pynetgear/__init__.py
@@ -574,10 +574,14 @@ class Netgear(object):
 
         try:
             try:
-                response = requests.post(self.soap_url, headers=headers,
-                                         data=message, timeout=30, verify=False)
+                response = requests.post(
+                    self.soap_url, headers=headers, data=message,
+                    timeout=30, verify=False
+                )
             except requests.exceptions.SSLError:
-                _LOGGER.debug("SSL error, thread as unauthorized response and try again after re-login")
+                _LOGGER.debug("SSL error, thread as unauthorized response "
+                    "and try again after re-login"
+                )
                 response = requests.Response()
                 response.status_code = 401
 

--- a/pynetgear/__init__.py
+++ b/pynetgear/__init__.py
@@ -573,8 +573,13 @@ class Netgear(object):
         message = SOAP_REQUEST.format(session_id=SESSION_ID, body=body)
 
         try:
-            response = requests.post(self.soap_url, headers=headers,
-                                     data=message, timeout=30, verify=False)
+            try:
+                response = requests.post(self.soap_url, headers=headers,
+                                         data=message, timeout=30, verify=False)
+            except requests.exceptions.SSLError:
+                _LOGGER.debug("SSL error, thread as unauthorized response and try again after re-login")
+                response = requests.Response()
+                response.status_code = 401
 
             if need_auth and _is_unauthorized_response(response):
                 # let's discard the cookie because it probably expired (v2)

--- a/pynetgear/__init__.py
+++ b/pynetgear/__init__.py
@@ -607,6 +607,7 @@ class Netgear(object):
 
         except requests.exceptions.RequestException:
             _LOGGER.exception("Error talking to API")
+            self.cookie = None
 
             # Maybe one day we will distinguish between
             # different errors..


### PR DESCRIPTION
If using a SSL port, pynetgear works just fine for about an hour, then the cockie expires and apperently instead of just getting a 401 response, you then start getting SSL: WRONG_VERSION_NUMBER errors.

```
2022-01-31 00:47:26 ERROR (SyncWorker_5) [pynetgear] Error talking to API
Traceback (most recent call last):
File "/usr/local/lib/python3.9/site-packages/urllib3/connectionpool.py", line 703, in urlopen
httplib_response = self._make_request(
File "/usr/local/lib/python3.9/site-packages/urllib3/connectionpool.py", line 449, in _make_request
six.raise_from(e, None)
File "<string>", line 3, in raise_from
File "/usr/local/lib/python3.9/site-packages/urllib3/connectionpool.py", line 444, in _make_request
httplib_response = conn.getresponse()
File "/usr/local/lib/python3.9/http/client.py", line 1371, in getresponse
response.begin()
File "/usr/local/lib/python3.9/http/client.py", line 319, in begin
version, status, reason = self._read_status()
File "/usr/local/lib/python3.9/http/client.py", line 280, in _read_status
line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
File "/usr/local/lib/python3.9/socket.py", line 704, in readinto
return self._sock.recv_into(b)
File "/usr/local/lib/python3.9/ssl.py", line 1241, in recv_into
return self.read(nbytes, buffer)
File "/usr/local/lib/python3.9/ssl.py", line 1099, in read
return self._sslobj.read(len, buffer)
ssl.SSLError: [SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:2633)
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
File "/usr/local/lib/python3.9/site-packages/requests/adapters.py", line 440, in send
resp = conn.urlopen(
File "/usr/local/lib/python3.9/site-packages/urllib3/connectionpool.py", line 785, in urlopen
retries = retries.increment(
File "/usr/local/lib/python3.9/site-packages/urllib3/util/retry.py", line 592, in increment
raise MaxRetryError(_pool, url, error or ResponseError(cause))
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='192.168.1.IP', port=xxxx): Max retries exceeded with url: /soap/server_sa/ (Caused by SSLError(SSLError(1, '[SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:2633)')))
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
File "/usr/local/lib/python3.9/site-packages/pynetgear/__init__.py", line 576, in _make_request
response = requests.post(self.soap_url, headers=headers,
File "/usr/local/lib/python3.9/site-packages/requests/api.py", line 117, in post
return request('post', url, data=data, json=json, **kwargs)
File "/usr/local/lib/python3.9/site-packages/requests/api.py", line 61, in request
return session.request(method=method, url=url, **kwargs)
File "/usr/local/lib/python3.9/site-packages/requests/sessions.py", line 529, in request
resp = self.send(prep, **send_kwargs)
File "/usr/local/lib/python3.9/site-packages/requests/sessions.py", line 645, in send
r = adapter.send(request, **kwargs)
File "/usr/local/lib/python3.9/site-packages/requests/adapters.py", line 517, in send
raise SSLError(e, request=request)
requests.exceptions.SSLError: HTTPSConnectionPool(host='192.168.1.IP', port=xxxx): Max retries exceeded with url: /soap/server_sa/ (Caused by SSLError(SSLError(1, '[SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:2633)')))
```

This PR fixes this in 2 ways:
- if an error occurs, invalidade the cookie such that on the next attempt a re-login is tried
- if a SSL error occurs, catch it, invalidade the cookie and try to re-login and repost the request, if it is an actual SSL error it will fail again and the SSL error will be loged, however if it was just a autentication problem, the request will suceed and no erros will be logged.