### PR TITLE
Support getting satellite information from Orbi systems

### DIFF
--- a/pynetgear/const.py
+++ b/pynetgear/const.py
@@ -78,6 +78,7 @@ GET_ATTACHED_DEVICES_2 = "GetAttachDevice2"
 GET_SYSTEM_INFO = "GetSystemInfo"
 # SET_DEVICE_NAME_ICON_BY_MAC = 'SetDeviceNameIconByMAC'
 # SET_DEVICE_NAME = 'SetNetgearDeviceName'
+GET_ALL_SATELLITES = "GetAllSatellites"
 
 # ---------------------
 # SERVICE_ADVANCED_QOS

--- a/pynetgear/router.py
+++ b/pynetgear/router.py
@@ -1221,3 +1221,30 @@ class Netgear(object):
             c.SET_SMART_CONNECT_ENABLED,
             {"NewSmartConnectEnable": value},
         )
+
+    def get_all_satellites(self):
+        """
+        Return list of connected satellites to the router with details.
+
+        Returns None if error occurred.
+        """
+        _LOGGER.debug("Get all satellites")
+
+        success, response = self._make_request(
+            c.SERVICE_DEVICE_INFO, c.GET_ALL_SATELLITES
+        )
+        if not success:
+            return None
+
+        success, satellites_node = h.find_node(
+            response.text, ".//GetAllSatellitesResponse/CurrentSatellites"
+        )
+        if not success:
+            return None
+
+        return list(
+            map(
+                lambda xml_sat: {sat.tag: sat.text for sat in xml_sat},
+                satellites_node.findall("satellite"),
+            )
+        )


### PR DESCRIPTION
Orbi satellite information does not get included via the attached devices calls, but rather has a separate `GetAllSatellites` method. This PR is mostly to get in on the radar and see how you would like to have it implemented in code.

Here is the response from my system when it is called:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<soap-env:Envelope
  xmlns:soap-env="http://schemas.xmlsoap.org/soap/envelope/"
    soap-env:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/"
    >
  <soap-env:Body>
    <m:GetAllSatellitesResponse
      xmlns:m="urn:NETGEAR-ROUTER:service:DeviceInfo:1">
      <CurrentSatellites>
        <satellite>
          <IP>10.69.0.3</IP>
          <MAC>34:98:B5:xx:xx:xx</MAC>
          <DeviceName>Satellite 2</DeviceName>
          <DeviceNameUserSet>true</DeviceNameUserSet>
          <ModelName>RBSE960</ModelName>
          <SerialNumber>redacted</SerialNumber>
          <SignalStrength>38</SignalStrength>
          <FWVersion>V6.3.7.10</FWVersion>
          <Hop>1</Hop>
          <ParentMac>34:98:B5:xx:xx:xx</ParentMac>
          <IsLightingLEDSupported>0</IsLightingLEDSupported>
          <LightingLEDOnOffStatus>0</LightingLEDOnOffStatus>
          <LightingLEDBrightnessStatus>0</LightingLEDBrightnessStatus>
          <AvsSupport>na</AvsSupport>
          <BHConnType>5GHz</BHConnType>
          <BHConnStatus>2</BHConnStatus>
        </satellite>
        <satellite>
          <IP>10.69.0.2</IP>
          <MAC>34:98:B5:xx:xx:xx</MAC>
          <DeviceName>Satellite 1</DeviceName>
          <DeviceNameUserSet>true</DeviceNameUserSet>
          <ModelName>RBSE960</ModelName>
          <SerialNumber>redacted</SerialNumber>
          <SignalStrength>40</SignalStrength>
          <FWVersion>V6.3.7.10</FWVersion>
          <Hop>1</Hop>
          <ParentMac>34:98:B5:xx:xx:xx</ParentMac>
          <IsLightingLEDSupported>0</IsLightingLEDSupported>
          <LightingLEDOnOffStatus>0</LightingLEDOnOffStatus>
          <LightingLEDBrightnessStatus>0</LightingLEDBrightnessStatus>
          <AvsSupport>na</AvsSupport>
          <BHConnType>5GHz</BHConnType>
          <BHConnStatus>2</BHConnStatus>
        </satellite>
      </CurrentSatellites>
    </m:GetAllSatellitesResponse>
    <ResponseCode>000</ResponseCode>
  </soap-env:Body>
</soap-env:Envelope>
```