### PR TITLE
Don't log when entry_count is too small

### DIFF
--- a/pynetgear/router.py
+++ b/pynetgear/router.py
@@ -613,7 +613,9 @@ class Netgear(object):
         if len(entries) > 1:
             entry_count = h.convert(entries.pop(0), int)
 
-        if entry_count is not None and entry_count != len(entries):
+        # Some devices like MR60 regulary return an entry_count too small
+        # Only log when entry_count is too big
+        if entry_count is not None and entry_count > len(entries):
             _LOGGER.info(
                 "Number of devices should be: %d but is: %d",
                 entry_count,


### PR DESCRIPTION
In router.py, get_attached_devices(), the list of attached devices it retrieved using a SOAP call. The returned object contains a list of which the first entry is supposed to contain the length of this list (minus 1). At least for the Nighthawk MR60, this number is often too low, resulting in a lot of log entries like:

```
Number of devices should be: 17 but is: 18
```

As this number is not actually being used in get_attached_devices(), it is of no harm to suppress this log message in these cases. Otherwise it clutters the log with harmless warnings which have no actual meaning.
